### PR TITLE
Add enum support via interface

### DIFF
--- a/fixtures/allow_additional_props.json
+++ b/fixtures/allow_additional_props.json
@@ -97,6 +97,34 @@
           },
           "type": "object"
         },
+        "test_enum_ptr": {
+          "enum": [
+            "d",
+            "e",
+            "f"
+          ]
+        },
+        "test_enum_ptr_ptr": {
+          "enum": [
+            "d",
+            "e",
+            "f"
+          ]
+        },
+        "test_enum_val": {
+          "enum": [
+            "a",
+            "b",
+            "c"
+          ]
+        },
+        "test_enum_val_ptr": {
+          "enum": [
+            "a",
+            "b",
+            "c"
+          ]
+        },
         "website": {
           "type": "string",
           "format": "uri"

--- a/fixtures/defaults.json
+++ b/fixtures/defaults.json
@@ -97,6 +97,34 @@
           },
           "type": "object"
         },
+        "test_enum_ptr": {
+          "enum": [
+            "d",
+            "e",
+            "f"
+          ]
+        },
+        "test_enum_ptr_ptr": {
+          "enum": [
+            "d",
+            "e",
+            "f"
+          ]
+        },
+        "test_enum_val": {
+          "enum": [
+            "a",
+            "b",
+            "c"
+          ]
+        },
+        "test_enum_val_ptr": {
+          "enum": [
+            "a",
+            "b",
+            "c"
+          ]
+        },
         "website": {
           "type": "string",
           "format": "uri"

--- a/fixtures/defaults_expanded_toplevel.json
+++ b/fixtures/defaults_expanded_toplevel.json
@@ -82,6 +82,34 @@
       },
       "type": "object"
     },
+    "test_enum_ptr": {
+      "enum": [
+        "d",
+        "e",
+        "f"
+      ]
+    },
+    "test_enum_ptr_ptr": {
+      "enum": [
+        "d",
+        "e",
+        "f"
+      ]
+    },
+    "test_enum_val": {
+      "enum": [
+        "a",
+        "b",
+        "c"
+      ]
+    },
+    "test_enum_val_ptr": {
+      "enum": [
+        "a",
+        "b",
+        "c"
+      ]
+    },
     "website": {
       "type": "string",
       "format": "uri"

--- a/fixtures/required_from_jsontags.json
+++ b/fixtures/required_from_jsontags.json
@@ -93,6 +93,34 @@
           },
           "type": "object"
         },
+        "test_enum_ptr": {
+          "enum": [
+            "d",
+            "e",
+            "f"
+          ]
+        },
+        "test_enum_ptr_ptr": {
+          "enum": [
+            "d",
+            "e",
+            "f"
+          ]
+        },
+        "test_enum_val": {
+          "enum": [
+            "a",
+            "b",
+            "c"
+          ]
+        },
+        "test_enum_val_ptr": {
+          "enum": [
+            "a",
+            "b",
+            "c"
+          ]
+        },
         "website": {
           "type": "string",
           "format": "uri"

--- a/reflect.go
+++ b/reflect.go
@@ -155,6 +155,12 @@ type protoEnum interface {
 
 var protoEnumType = reflect.TypeOf((*protoEnum)(nil)).Elem()
 
+type jsonSchemaEnums interface {
+	JSONSchemaEnums() []interface{}
+}
+
+var jsonSchemaEnumsType = reflect.TypeOf((*jsonSchemaEnums)(nil)).Elem()
+
 func (r *Reflector) reflectTypeToSchema(definitions Definitions, t reflect.Type) *Type {
 	// Already added to definitions?
 	if _, ok := definitions[t.Name()]; ok {
@@ -168,6 +174,18 @@ func (r *Reflector) reflectTypeToSchema(definitions Definitions, t reflect.Type)
 			{Type: "string"},
 			{Type: "integer"},
 		}}
+	}
+
+	if t.Implements(jsonSchemaEnumsType) ||
+		(t.Kind() != reflect.Ptr && reflect.PtrTo(t).Implements(jsonSchemaEnumsType)) {
+		if t.Kind() == reflect.Ptr {
+			return &Type{
+				Enum: reflect.New(t.Elem()).Interface().(jsonSchemaEnums).JSONSchemaEnums(),
+			}
+		}
+		return &Type{
+			Enum: reflect.New(t).Interface().(jsonSchemaEnums).JSONSchemaEnums(),
+		}
 	}
 
 	// Defined format types for JSON Schema Validation

--- a/reflect_test.go
+++ b/reflect_test.go
@@ -44,6 +44,18 @@ const (
 	Great
 )
 
+type ABCEnumVal string
+
+func (ABCEnumVal) JSONSchemaEnums() []interface{} {
+	return []interface{}{"a", "b", "c"}
+}
+
+type DEFEnumPtr string
+
+func (*DEFEnumPtr) JSONSchemaEnums() []interface{} {
+	return []interface{}{"d", "e", "f"}
+}
+
 type TestUser struct {
 	SomeBaseType
 	nonExported
@@ -68,6 +80,11 @@ type TestUser struct {
 	Feeling ProtoEnum `json:"feeling,omitempty"`
 	Age     int       `json:"age" jsonschema:"minimum=18,maximum=120,exclusiveMaximum=true,exclusiveMinimum=true"`
 	Email   string    `json:"email" jsonschema:"format=email"`
+
+	TestEnumVal    ABCEnumVal  `json:"test_enum_val,omitempty"`
+	TestEnumValPtr *ABCEnumVal `json:"test_enum_val_ptr,omitempty"`
+	TestEnumPtr    DEFEnumPtr  `json:"test_enum_ptr,omitempty"`
+	TestEnumPtrPtr *DEFEnumPtr `json:"test_enum_ptr_ptr,omitempty"`
 }
 
 var schemaGenerationTests = []struct {


### PR DESCRIPTION
If a type implements JSONSchemaEnums() it will be assumed to be a
enum and be called to get enum values.